### PR TITLE
CPU Monitoring update

### DIFF
--- a/IO.TrakerrClient/CPUUsageTracker.cs
+++ b/IO.TrakerrClient/CPUUsageTracker.cs
@@ -94,36 +94,28 @@ namespace IO.TrakerrClient
             /// </summary>
             private void Poll()
             {
-                try
+                while (true)
                 {
-                    while (true)
+                    if (shutdown) return;
+                    try
                     {
-                        if (shutdown) return;
-                        try
-                        {
-                            CpuPercentUse = (int)Math.Round(cpuCounter.NextValue(), MidpointRounding.AwayFromZero);
-                        }
-                        catch (Win32Exception)
-                        {
-                            //Error with the WMI.
-                        }
-                        catch (PlatformNotSupportedException)
-                        {
-                            //Windows this program is run on is too old.
-                            return;
-                        }
-                        catch (UnauthorizedAccessException)
-                        {
-                            //Needs to be run from a more elavted positions.
-                            return;
-                        }
-                        Thread.Sleep(interval);
+                        CpuPercentUse = (int)Math.Round(cpuCounter.NextValue(), MidpointRounding.AwayFromZero);
                     }
-
-                }
-                finally
-                {
-                    Console.WriteLine("CPU THREAD EXITTING: " + shutdown);
+                    catch (Win32Exception)
+                    {
+                        //Error with the WMI.
+                    }
+                    catch (PlatformNotSupportedException)
+                    {
+                        //The Windows this program is run on is too old.
+                        return;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        //Needs to be run from a more elavted positions.
+                        return;
+                    }
+                    Thread.Sleep(interval);
                 }
 
             }

--- a/IO.TrakerrClient/CPUUsageTracker.cs
+++ b/IO.TrakerrClient/CPUUsageTracker.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Threading;
+
+namespace IO.TrakerrClient
+{
+    class CPUUsageTracker
+    {
+        private static CPUUsageTracker cpuusagetracker;
+        private static uint numref = 0;
+
+        private PerformanceCounter cpuCounter;
+        private volatile int cpupercentuse = 0;
+        private Thread pollingthread;
+        private int interval;
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool IsShutdown { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static CPUUsageTracker CpuUsageTracker
+        {
+            get
+            {
+                if (cpuusagetracker == null)
+                {
+                    cpuusagetracker = new CPUUsageTracker(1000);
+                }
+                numref++;
+                return cpuusagetracker;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public int CpuPercentUse
+        {
+            get
+            {
+                return cpupercentuse;
+            }
+            private set
+            {
+                cpupercentuse = value;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="pollinterval"></param>
+        private CPUUsageTracker(int pollinterval)
+        {
+            try
+            {
+                cpuCounter = new PerformanceCounter("Processor", "% Processor Time", "_Total");
+                cpuCounter.NextValue();
+            }
+            catch (Win32Exception)
+            {
+                //Error with the WMI.
+            }
+            catch (PlatformNotSupportedException)
+            {
+                //Windows this program is run on is too old.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Console.Error.WriteLine("Logger does not have permission to get the CPU info");
+            }
+            interval = pollinterval;
+
+            if (cpuCounter != null)
+            {
+                pollingthread = new Thread(new ThreadStart(Poll));
+                pollingthread.Start();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="forceShudown"></param>
+        public void Shutdown(bool forceShudown)
+        {
+            if (numref > 0) numref--;
+            if (numref == 0) IsShutdown = true;
+
+            if (pollingthread != null && forceShudown)
+            {
+                pollingthread.Abort();
+                IsShutdown = true;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void Poll()
+        {
+            while (true)
+            {
+                if (IsShutdown) return;
+                try
+                {
+                    CpuPercentUse = (int)Math.Round(cpuCounter.NextValue(), MidpointRounding.AwayFromZero);
+                }
+                catch (Win32Exception)
+                {
+                    //Error with the WMI.
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    //Windows this program is run on is too old.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    //Needs to be run from a more elavted positions.
+                }
+                Thread.Sleep(interval);
+            }
+
+        }
+    }
+
+
+}

--- a/IO.TrakerrClient/IO.TrakerrClient.csproj
+++ b/IO.TrakerrClient/IO.TrakerrClient.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CPUUsageTracker.cs" />
     <Compile Include="EventTraceBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TrakerrClient.cs" />

--- a/IO.TrakerrClient/Properties/AssemblyInfo.cs
+++ b/IO.TrakerrClient/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1")]
+[assembly: AssemblyFileVersion("1.1.1")]

--- a/IO.TrakerrClient/TrakerrClient.cs
+++ b/IO.TrakerrClient/TrakerrClient.cs
@@ -268,12 +268,12 @@ namespace IO.TrakerrClient
         /// Send the AppEvent to Trakerr asynchronously. If any of the parameters supplied in the constructor are not supplied in the AppEvent parameter, this will auto-populate those members before sending the event to Trakerr.
         /// </summary>
         /// <param name="appEvent">The event to send</param>
-        public async void SendEventAsync(AppEvent appEvent)
+        public async System.Threading.Tasks.Task<ApiResponse<Object>> SendEventAsync(AppEvent appEvent)
         {
             // fill defaults if not overridden in the AppEvent being passed
             FillDefaults(appEvent);
 
-            var response = await eventsApi.EventsPostAsyncWithHttpInfo(appEvent);
+            return await eventsApi.EventsPostAsyncWithHttpInfo(appEvent);
             /*await Console.Error.WriteLineAsync("Status Code:" + response.StatusCode);
             await Console.Error.WriteLineAsync(response.Data.ToString());Debug statements*/
         }

--- a/IO.TrakerrClient/TrakerrClient.cs
+++ b/IO.TrakerrClient/TrakerrClient.cs
@@ -37,7 +37,8 @@ namespace IO.TrakerrClient
         {
             var client = new TrakerrClient();
 
-            client.SendEventAsync(client.CreateAppEvent(e, AppEvent.LogLevelEnum.Error, classification));
+            var task = client.SendEventAsync(client.CreateAppEvent(e, AppEvent.LogLevelEnum.Error, classification));
+            task.Wait();
         }
     }
 
@@ -63,7 +64,7 @@ namespace IO.TrakerrClient
     {
         private static DateTime DT_EPOCH = new DateTime(1970, 1, 1);
         private EventsApi eventsApi;
-        private CPUUsageTracker cpuperf;
+        private CPUUsageTrackerFactory.CPUUsageTracker cpuperf = CPUUsageTrackerFactory.CpuUsageTracker;
 
         public string apiKey { get; set; }
         public string ContextAppVersion { get; set; }
@@ -201,8 +202,6 @@ namespace IO.TrakerrClient
             eventsApi = new EventsApi(ConfigurationManager.AppSettings["trakerr.url"]);
             this.ContextTags = contextTags;
             this.ContextAppSKU = contextAppSKU;
-
-            cpuperf = CPUUsageTracker.CpuUsageTracker;
         }
 
         /// <summary>
@@ -269,7 +268,8 @@ namespace IO.TrakerrClient
         /// <param name="classification">Optional extra string descriptor. Defaults to issue.</param>
         public void SendException(Exception e, AppEvent.LogLevelEnum logLevel = AppEvent.LogLevelEnum.Error, string classification = "issue")
         {
-            SendEventAsync(CreateAppEvent(e, logLevel, classification));
+            var task = SendEventAsync(CreateAppEvent(e, logLevel, classification));
+            task.Wait();
         }
 
         /// <summary>
@@ -362,11 +362,5 @@ namespace IO.TrakerrClient
             // that 4.5 or later is installed.
             return "No 4.5 or later version detected";
         }
-
-        ~TrakerrClient()
-        {
-            cpuperf.Shutdown(false);
-        }
-
     }
 }

--- a/IO.TrakerrClient/_CreateNewNuGetPackage/Config.ps1
+++ b/IO.TrakerrClient/_CreateNewNuGetPackage/Config.ps1
@@ -16,7 +16,7 @@
 # Specify the Version Number to use for the NuGet package. If not specified, the version number of the assembly being packed will be used.
 # NuGet version number guidance: https://docs.nuget.org/docs/reference/versioning and the Semantic Versioning spec: http://semver.org/
 # e.g. "" (use assembly's version), "1.2.3" (stable version), "1.2.3-alpha" (prerelease version).
-$versionNumber = "1.1.0"
+$versionNumber = "1.1.1"
 
 # Specify any Release Notes for this package. 
 # These will only be included in the package if you have a .nuspec file for the project in the same directory as the project file.

--- a/README.md
+++ b/README.md
@@ -78,10 +78,21 @@ To send an exception to Trakerr, it's as simple as calling .SendToTrakerr() on t
 
 ```
 
+## Closing the logger
+When cleaning up your application, or implementing a shutdown, be sure to call
+
+```csharp
+TrakerrClient tc = new TrakerrClient(...)
+
+...
+
+//application cleanup on exit
+tc.Shutdown(false);
+```
+
+This will close the CPU monitoring thread gracefully. If an error has occurred passing `true` pass a hard thread abort. Do not pass true unless absolutely nessarry.
 
 ## Detailed Integration Guide
-
-
 ### Option-1: Send an exception to Trakerr
 Use the guide [3-minute integration guide above](#3-minute-Integration-Guide) to send an exception to Trakerr.
 
@@ -186,7 +197,6 @@ This creates a new  [Model.AppEvent](https://github.com/trakerr-io/trakerr-cshar
 ```
 
 ## About TrakerrClient's properties
-
 The `TrakerrClient` class above can be constructed to take aditional data, rather than using the configured defaults. The constructor signature is:
 
 ```csharp

--- a/TrakerrSampleApp/App.config
+++ b/TrakerrSampleApp/App.config
@@ -4,7 +4,7 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
     <appSettings>
-      <add key="trakerr.apiKey" value="Your API key here" />
+      <add key="trakerr.apiKey" value="eefea6e9b269190715181109c44a7a0810905114236106" />
       <add key="trakerr.url" value="https://www.trakerr.io/api/v1" />
       <add key="trakerr.contextAppVersion" value="1.0" />
       <add key="trakerr.deploymentStage" value="development"/>

--- a/TrakerrSampleApp/App.config
+++ b/TrakerrSampleApp/App.config
@@ -1,12 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
-    </startup>
-    <appSettings>
-      <add key="trakerr.apiKey" value="Your API key here" />
-      <add key="trakerr.url" value="https://www.trakerr.io/api/v1" />
-      <add key="trakerr.contextAppVersion" value="1.0" />
-      <add key="trakerr.deploymentStage" value="development"/>
-    </appSettings>
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+    <appSettings>
+      <add key="trakerr.apiKey" value="bb0e988a32005ff79b8449e76680f84d26280373689907" />
+      <add key="trakerr.url" value="https://www.trakerr.io/api/v1" />
+      <add key="trakerr.contextAppVersion" value="1.0" />
+      <add key="trakerr.deploymentStage" value="development"/>
+    </appSettings>
 </configuration>

--- a/TrakerrSampleApp/App.config
+++ b/TrakerrSampleApp/App.config
@@ -1,12 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
-    </startup>
-    <appSettings>
-      <add key="trakerr.apiKey" value="eefea6e9b269190715181109c44a7a0810905114236106" />
-      <add key="trakerr.url" value="https://www.trakerr.io/api/v1" />
-      <add key="trakerr.contextAppVersion" value="1.0" />
-      <add key="trakerr.deploymentStage" value="development"/>
-    </appSettings>
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+    <appSettings>
+      <add key="trakerr.apiKey" value="Your API key here" />
+      <add key="trakerr.url" value="https://www.trakerr.io/api/v1" />
+      <add key="trakerr.contextAppVersion" value="1.0" />
+      <add key="trakerr.deploymentStage" value="development"/>
+    </appSettings>
 </configuration>

--- a/TrakerrSampleApp/Program.cs
+++ b/TrakerrSampleApp/Program.cs
@@ -1,92 +1,98 @@
-﻿using IO.TrakerrClient;
-using IO.Trakerr.Model;
-using System;
-using System.Threading.Tasks;
-
-namespace TrakerrSampleApp
-{
-    /// <summary>
-    /// Sample program to generate an event
-    /// </summary>
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var t = execute();
-            t.Wait();
-            return;
-        }
-        public static async Task execute()
-        {
-            System.Threading.Thread.Sleep(2000);
-            //Option 1: Send to Trakerr automatically.
-            try
-            {
-
-                throw new Exception("This is a test exception.");
-            }
-            catch (Exception e)
-            {
-                // Send the event to Trakerr
-                e.SendToTrakerr();
-            }
-
-            //Option 2: Send to Trakker using the client API.
-            TrakerrClient tc = new TrakerrClient();
-
-            try
-            {
-                throw new ArgumentException("Args are invalid.");
-            }
-            catch (Exception e)
-            {
-                tc.SendException(e);//Can also change the log level, along with the classifcation, unlike the above which only changes issue.
-            }
-
-            //Option 3: Send an exception to Trakerr with custom data.
-            try
-            {
-                throw new IndexOutOfRangeException("Buffer overflow.");
-            }
-            catch (Exception e)
-            {
-                for(var i = 0; i < 100; i++)
-                {
-                    try
-                    {
-                        var appevent = tc.CreateAppEvent(e, AppEvent.LogLevelEnum.Fatal);//Can also change the classification.
-                                                                                         //EventType and EventMessage are set automatically by create app event; you can set them manually from the appevent instance too.
-                        appevent.EventUser = "john@trakerr.io";
-                        appevent.EventSession = "8";
-
-                        appevent.CustomProperties = new CustomData();
-                        appevent.CustomProperties.StringData = new CustomStringData("This is string data 1!");//Add up to 10 custom strings.
-                        appevent.CustomProperties.StringData.CustomData2 = "This is string data 2!";//You can also add strings later like this.
-                        appevent.ContextOperationTimeMillis = 1000;
-
-                        var response = await tc.SendEventAsync(appevent);
-                        Console.WriteLine("Status[" + i + "]: " + response.StatusCode);
-
-                    }
-                    catch (Exception ie)
-                    {
-                        Console.WriteLine("Error["  + i + "]: " + ie.Message);
-                    }
-                }
-            }
-
-            //Option 4: Send a non-exception to Trakerr.
-            var infoevent = tc.CreateAppEvent(AppEvent.LogLevelEnum.Info, "CLICK_EVENT", "Feature Analytics", "Some Feature");
-            infoevent.EventUser = "jill@trakerr.io";
-            infoevent.EventSession = "2";
-
-            //Populate any other data you want, customdata or overriding default values of the appevent.
-
-            await tc.SendEventAsync(infoevent);
-            // Console.In.ReadLine();//Give time for the Async tasks to print to console for the sample app.
-            tc.Shutdown(false); //IMPORTANT: Uncomment this line if you are using the VS debugger.
-        }
-    }
-}
-
-
+﻿using IO.TrakerrClient;
+
+
+using IO.Trakerr.Model;
+
+using System;
+using System.Threading.Tasks;
+
+
+namespace TrakerrSampleApp
+{
+
+    /// <summary>
+    /// Sample program to generate an event
+    /// </summary>
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var t = execute();
+            t.Wait();
+            return;
+        }
+
+
+        public static async Task execute()
+        {
+            System.Threading.Thread.Sleep(2000);//Test to populate CPU info
+
+            //Option 1: Send to Trakerr automatically.
+            try
+            {
+                throw new Exception("This is a test exception.");
+            }
+            catch (Exception e)
+            {
+                // Send the event to Trakerr
+                e.SendToTrakerr();
+            }
+
+            //Option 2: Send to Trakker using the client API.
+            TrakerrClient tc = new TrakerrClient();
+
+            try
+            {
+                throw new ArgumentException("Args are invalid.");
+            }
+            catch (Exception e)
+            {
+                tc.SendException(e);//Can also change the log level, along with the classifcation, unlike the above which only changes issue.
+            }
+
+            //Option 3: Send an exception to Trakerr with custom data.
+            try
+            {
+                throw new IndexOutOfRangeException("Buffer overflow.");
+            }
+            catch (Exception e)
+            {
+                for (var i = 0; i < 100; i++)
+                {
+                    try
+                    {
+                        var appevent = tc.CreateAppEvent(e, AppEvent.LogLevelEnum.Fatal);//Can also change the classification.
+
+                        //EventType and EventMessage are set automatically by create app event; you can set them manually from the appevent instance too.
+                        appevent.EventUser = "john@trakerr.io";
+                        appevent.EventSession = "8";
+                        appevent.CustomProperties = new CustomData();
+                        appevent.CustomProperties.StringData = new CustomStringData("This is string data 1!");//Add up to 10 custom strings.
+                        appevent.CustomProperties.StringData.CustomData2 = "This is string data 2!";//You can also add strings later like this.
+                        appevent.ContextOperationTimeMillis = 1000;
+
+                        var response = await tc.SendEventAsync(appevent);
+
+                        Console.WriteLine("Status[" + i + "]: " + response.StatusCode);
+                    }
+                    catch (Exception ie)
+                    {
+                        Console.WriteLine("Error[" + i + "]: " + ie.Message);
+                    }
+                }
+            }
+
+            //Option 4: Send a non-exception to Trakerr.
+            var infoevent = tc.CreateAppEvent(AppEvent.LogLevelEnum.Info, "CLICK_EVENT", "Feature Analytics", "Some Feature");
+
+            infoevent.EventUser = "jill@trakerr.io";
+            infoevent.EventSession = "2";
+            //Populate any other data you want, customdata or overriding default values of the appevent.
+            infoevent.ContextOperationTimeMillis = 1000;
+
+            await tc.SendEventAsync(infoevent);
+            // Console.In.ReadLine();//Give time for the Async tasks to print to console for the sample app.
+            tc.Shutdown(false);
+        }
+    }
+}

--- a/TrakerrSampleApp/Program.cs
+++ b/TrakerrSampleApp/Program.cs
@@ -1,6 +1,7 @@
 ﻿using IO.TrakerrClient;
 using IO.Trakerr.Model;
 using System;
+using System.Threading.Tasks;
 
 namespace TrakerrSampleApp
 {
@@ -11,10 +12,11 @@ namespace TrakerrSampleApp
     {
         static void Main(string[] args)
         {
-            execute();
+            var t = execute();
+            t.Wait();
             return;
         }
-        public static async void execute()
+        public static async Task execute()
         {
             System.Threading.Thread.Sleep(2000);
             //Option 1: Send to Trakerr automatically.
@@ -48,28 +50,41 @@ namespace TrakerrSampleApp
             }
             catch (Exception e)
             {
-                var appevent = tc.CreateAppEvent(e, AppEvent.LogLevelEnum.Fatal);//Can also change the classification.
-                //EventType and EventMessage are set automatically by create app event; you can set them manually from the appevent instance too.
-                appevent.EventUser = "john@trakerr.io";
-                appevent.EventSession = "8";
+                for(var i = 0; i < 100; i++)
+                {
+                    try
+                    {
+                        var appevent = tc.CreateAppEvent(e, AppEvent.LogLevelEnum.Fatal);//Can also change the classification.
+                                                                                         //EventType and EventMessage are set automatically by create app event; you can set them manually from the appevent instance too.
+                        appevent.EventUser = "john@trakerr.io";
+                        appevent.EventSession = "8";
 
-                appevent.CustomProperties = new CustomData();
-                appevent.CustomProperties.StringData = new CustomStringData("This is string data 1!");//Add up to 10 custom strings.
-                appevent.CustomProperties.StringData.CustomData2 = "This is string data 2!";//You can also add strings later like this.
-                appevent.ContextOperationTimeMillis = 1000;
+                        appevent.CustomProperties = new CustomData();
+                        appevent.CustomProperties.StringData = new CustomStringData("This is string data 1!");//Add up to 10 custom strings.
+                        appevent.CustomProperties.StringData.CustomData2 = "This is string data 2!";//You can also add strings later like this.
+                        appevent.ContextOperationTimeMillis = 1000;
 
-                await tc.SendEventAsync(appevent);
+                        var response = await tc.SendEventAsync(appevent);
+                        Console.WriteLine("Status[" + i + "]: " + response.StatusCode);
+
+                    }
+                    catch (Exception ie)
+                    {
+                        Console.WriteLine("Error["  + i + "]: " + ie.Message);
+                    }
+                }
             }
 
             //Option 4: Send a non-exception to Trakerr.
-            var infoevent = tc.CreateAppEvent(AppEvent.LogLevelEnum.Info, "User sends clicked this button", "Feature Analytics", "Some Feature");
+            var infoevent = tc.CreateAppEvent(AppEvent.LogLevelEnum.Info, "CLICK_EVENT", "Feature Analytics", "Some Feature");
             infoevent.EventUser = "jill@trakerr.io";
             infoevent.EventSession = "2";
 
             //Populate any other data you want, customdata or overriding default values of the appevent.
 
             await tc.SendEventAsync(infoevent);
-            Console.In.ReadLine();//Give time for the Async tasks to print to console for the sample app.
+            // Console.In.ReadLine();//Give time for the Async tasks to print to console for the sample app.
+            tc.Shutdown(false);
         }
     }
 }

--- a/TrakerrSampleApp/Program.cs
+++ b/TrakerrSampleApp/Program.cs
@@ -11,10 +11,16 @@ namespace TrakerrSampleApp
     {
         static void Main(string[] args)
         {
+            execute();
+            return;
+        }
+        public static async void execute()
+        {
+            System.Threading.Thread.Sleep(2000);
             //Option 1: Send to Trakerr automatically.
             try
             {
-                
+
                 throw new Exception("This is a test exception.");
             }
             catch (Exception e)
@@ -52,7 +58,7 @@ namespace TrakerrSampleApp
                 appevent.CustomProperties.StringData.CustomData2 = "This is string data 2!";//You can also add strings later like this.
                 appevent.ContextOperationTimeMillis = 1000;
 
-                tc.SendEventAsync(appevent);
+                await tc.SendEventAsync(appevent);
             }
 
             //Option 4: Send a non-exception to Trakerr.
@@ -62,9 +68,10 @@ namespace TrakerrSampleApp
 
             //Populate any other data you want, customdata or overriding default values of the appevent.
 
-            tc.SendEventAsync(infoevent);
-
-            //Console.In.ReadLine();//Give time for the Async tasks to print to console for the sample app.
+            await tc.SendEventAsync(infoevent);
+            Console.In.ReadLine();//Give time for the Async tasks to print to console for the sample app.
         }
     }
 }
+
+

--- a/TrakerrSampleApp/Program.cs
+++ b/TrakerrSampleApp/Program.cs
@@ -1,92 +1,92 @@
-﻿using IO.TrakerrClient;
-using IO.Trakerr.Model;
-using System;
-using System.Threading.Tasks;
-
-namespace TrakerrSampleApp
-{
-    /// <summary>
-    /// Sample program to generate an event
-    /// </summary>
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var t = execute();
-            t.Wait();
-            return;
-        }
-        public static async Task execute()
-        {
-            System.Threading.Thread.Sleep(2000);
-            //Option 1: Send to Trakerr automatically.
-            try
-            {
-
-                throw new Exception("This is a test exception.");
-            }
-            catch (Exception e)
-            {
-                // Send the event to Trakerr
-                e.SendToTrakerr();
-            }
-
-            //Option 2: Send to Trakker using the client API.
-            TrakerrClient tc = new TrakerrClient();
-
-            try
-            {
-                throw new ArgumentException("Args are invalid.");
-            }
-            catch (Exception e)
-            {
-                tc.SendException(e);//Can also change the log level, along with the classifcation, unlike the above which only changes issue.
-            }
-
-            //Option 3: Send an exception to Trakerr with custom data.
-            try
-            {
-                throw new IndexOutOfRangeException("Buffer overflow.");
-            }
-            catch (Exception e)
-            {
-                for(var i = 0; i < 100; i++)
-                {
-                    try
-                    {
-                        var appevent = tc.CreateAppEvent(e, AppEvent.LogLevelEnum.Fatal);//Can also change the classification.
-                                                                                         //EventType and EventMessage are set automatically by create app event; you can set them manually from the appevent instance too.
-                        appevent.EventUser = "john@trakerr.io";
-                        appevent.EventSession = "8";
-
-                        appevent.CustomProperties = new CustomData();
-                        appevent.CustomProperties.StringData = new CustomStringData("This is string data 1!");//Add up to 10 custom strings.
-                        appevent.CustomProperties.StringData.CustomData2 = "This is string data 2!";//You can also add strings later like this.
-                        appevent.ContextOperationTimeMillis = 1000;
-
-                        var response = await tc.SendEventAsync(appevent);
-                        Console.WriteLine("Status[" + i + "]: " + response.StatusCode);
-
-                    }
-                    catch (Exception ie)
-                    {
-                        Console.WriteLine("Error["  + i + "]: " + ie.Message);
-                    }
-                }
-            }
-
-            //Option 4: Send a non-exception to Trakerr.
-            var infoevent = tc.CreateAppEvent(AppEvent.LogLevelEnum.Info, "CLICK_EVENT", "Feature Analytics", "Some Feature");
-            infoevent.EventUser = "jill@trakerr.io";
-            infoevent.EventSession = "2";
-
-            //Populate any other data you want, customdata or overriding default values of the appevent.
-
-            await tc.SendEventAsync(infoevent);
-            // Console.In.ReadLine();//Give time for the Async tasks to print to console for the sample app.
-            tc.Shutdown(false);
-        }
-    }
-}
-
-
+﻿using IO.TrakerrClient;
+using IO.Trakerr.Model;
+using System;
+using System.Threading.Tasks;
+
+namespace TrakerrSampleApp
+{
+    /// <summary>
+    /// Sample program to generate an event
+    /// </summary>
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var t = execute();
+            t.Wait();
+            return;
+        }
+        public static async Task execute()
+        {
+            System.Threading.Thread.Sleep(2000);
+            //Option 1: Send to Trakerr automatically.
+            try
+            {
+
+                throw new Exception("This is a test exception.");
+            }
+            catch (Exception e)
+            {
+                // Send the event to Trakerr
+                e.SendToTrakerr();
+            }
+
+            //Option 2: Send to Trakker using the client API.
+            TrakerrClient tc = new TrakerrClient();
+
+            try
+            {
+                throw new ArgumentException("Args are invalid.");
+            }
+            catch (Exception e)
+            {
+                tc.SendException(e);//Can also change the log level, along with the classifcation, unlike the above which only changes issue.
+            }
+
+            //Option 3: Send an exception to Trakerr with custom data.
+            try
+            {
+                throw new IndexOutOfRangeException("Buffer overflow.");
+            }
+            catch (Exception e)
+            {
+                for(var i = 0; i < 100; i++)
+                {
+                    try
+                    {
+                        var appevent = tc.CreateAppEvent(e, AppEvent.LogLevelEnum.Fatal);//Can also change the classification.
+                                                                                         //EventType and EventMessage are set automatically by create app event; you can set them manually from the appevent instance too.
+                        appevent.EventUser = "john@trakerr.io";
+                        appevent.EventSession = "8";
+
+                        appevent.CustomProperties = new CustomData();
+                        appevent.CustomProperties.StringData = new CustomStringData("This is string data 1!");//Add up to 10 custom strings.
+                        appevent.CustomProperties.StringData.CustomData2 = "This is string data 2!";//You can also add strings later like this.
+                        appevent.ContextOperationTimeMillis = 1000;
+
+                        var response = await tc.SendEventAsync(appevent);
+                        Console.WriteLine("Status[" + i + "]: " + response.StatusCode);
+
+                    }
+                    catch (Exception ie)
+                    {
+                        Console.WriteLine("Error["  + i + "]: " + ie.Message);
+                    }
+                }
+            }
+
+            //Option 4: Send a non-exception to Trakerr.
+            var infoevent = tc.CreateAppEvent(AppEvent.LogLevelEnum.Info, "CLICK_EVENT", "Feature Analytics", "Some Feature");
+            infoevent.EventUser = "jill@trakerr.io";
+            infoevent.EventSession = "2";
+
+            //Populate any other data you want, customdata or overriding default values of the appevent.
+
+            await tc.SendEventAsync(infoevent);
+            // Console.In.ReadLine();//Give time for the Async tasks to print to console for the sample app.
+            tc.Shutdown(false); //IMPORTANT: Uncomment this line if you are using the VS debugger.
+        }
+    }
+}
+
+

--- a/TrakerrSampleApp/TrakerrSampleApp.csproj
+++ b/TrakerrSampleApp/TrakerrSampleApp.csproj
@@ -14,7 +14,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>


### PR DESCRIPTION
Delegates the CPU to a separate thread. Some interesting behavior observed:

The sample app deadlocks with the Debugger on. I believe, this is because the debugger expects Thread to be released before calling the GC on the destructor , and the GC won't release TrakerrClient until the thread it's holding onto clears up. The fix is simple, raise the graceful shutdown manually, and it will proceed with disposing the thread and releasing the TC the debugger holds. The line is included with the sample app, to be un-commented. THIS ONLY HAPPENS IN A DEBUGGING ENVIRONMENT. The sample app runs fine without the debugger.

I also extended the java design just slightly to include an reference manager. I decided that if people wanted to close their logger but keep the application running for whatever reason, we shouldn't keep it going, so I keep track of the number of instances the cpuperf is 'created' from. Each shutdown check to see if someone is still using the thread, and shuts down only when it reaches 0 under graceful shutdown calls. You can interrupt the thread forcefully, of course and that will pass an abort, although this isn't exactly graceful.